### PR TITLE
Only force name to all caps for programs

### DIFF
--- a/main.c
+++ b/main.c
@@ -455,7 +455,8 @@ show_help:
         
         /* write program name */
         var_name[name_length] = '\0';
-        strtoupper(var_name);
+        if (var_type == TYPE_PRGM)
+            strtoupper(var_name);
     }
 
     /* determine file type */


### PR DESCRIPTION
`convhex` forces the appvar output name to ALL CAPS. This makes sense for programs, but not for groups and appvar, which TI Connect will happily send to calculators without changing their name or complaining. And I notice that `LibLoad` isn't named LIBLOAD.