### PR TITLE
convert: fix elf => 8ek conversion.

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -736,11 +736,14 @@ static int convert_8ek(struct input *input, struct output_file *file)
     const uint8_t *reloc_table;
     uint8_t *output_data;
     uint8_t *ptr;
-    uint8_t *app_header_start;
     size_t input_size = 0;
-    size_t app_total_size = 0;
+    size_t app_payload_size = 0;
+    size_t app_extended_size = 0;
+    size_t app_master_size = 0;
     size_t app_data_size;
     size_t reloc_size = 0;
+    size_t init_data_offset = 0;
+    size_t init_data_size = 0;
     size_t i;
     uint32_t tmp;
     size_t output_size;
@@ -758,18 +761,26 @@ static int convert_8ek(struct input *input, struct output_file *file)
 
     reloc_size = input->files[0].reloc_table.size;
     reloc_table = input->files[0].reloc_table.data;
+    init_data_offset = input->files[0].reloc_table.init_offset;
+    init_data_size = input->files[0].reloc_table.init_size;
     input_data = input->files[0].data;
     input_size = input->files[0].size;
 
-    app_total_size = input_size + reloc_size + file->description_size + (file->description_size ? 1 : 0);
+    if (init_data_size > 0 && init_data_offset + init_data_size > input_size)
+    {
+        LOG_ERROR("ELF initialized data range out of bounds.\n");
+        return -1;
+    }
+
+    app_payload_size = input_size + reloc_size + file->description_size + (file->description_size ? 1 : 0);
+    app_extended_size = TI8EK_APP_METADATA_SIZE + app_payload_size;
+    app_master_size = (TI8EK_APP_HEADER_SIZE - 6) + app_extended_size;
     app_data_size =
         TI8EK_APP_HEADER_SIZE +
-        TI8EK_APP_METADATA_SIZE +
-        app_total_size +
-        TI8EK_APP_SIGNATURE_FIELD_SIZE +
-        TI8EK_APP_SIGNATURE_TYPE_SIZE +
+        app_extended_size +
+        4 + /* 0x023E field + 16-bit signature length */
         TI8EK_APP_SIGNATURE_SIZE;
-    output_size = TI8X_FILE_HEADER_LEN + TI8X_VAR_HEADER_LEN + app_data_size;
+    output_size = TI8EK_APP_HEADER_OFFSET + app_data_size;
 
     if (output_reserve_data(file, output_size) != 0)
     {
@@ -814,13 +825,13 @@ static int convert_8ek(struct input *input, struct output_file *file)
     *ptr++ = app_data_size >> 24;
 
     /* Application Header */
-    ptr = app_header_start = &output_data[TI8EK_APP_HEADER_OFFSET];
+    ptr = &output_data[TI8EK_APP_HEADER_OFFSET];
     *ptr++ = 0x81;
     *ptr++ = 0x0F;
-    *ptr++ = app_total_size >> 24;
-    *ptr++ = app_total_size >> 16;
-    *ptr++ = app_total_size >> 8;
-    *ptr++ = app_total_size >> 0;
+    *ptr++ = app_master_size >> 24;
+    *ptr++ = app_master_size >> 16;
+    *ptr++ = app_master_size >> 8;
+    *ptr++ = app_master_size >> 0;
     *ptr++ = 0x81;
     *ptr++ = 0x12;
     *ptr++ = 0x13;
@@ -862,14 +873,14 @@ static int convert_8ek(struct input *input, struct output_file *file)
     *ptr++ = 0xDC;
     *ptr++ = 0x00;
     *ptr++ = 0x0D;
-    *ptr = TI8EK_APP_HEADER_SIZE - (ptr - app_header_start);
+    *ptr = (uint8_t)(&output_data[TI8EK_APP_HEADER_SIZE_FIELD_OFFSET] - (ptr + 1));
     ptr = &output_data[TI8EK_APP_HEADER_SIZE_FIELD_OFFSET];
     *ptr++ = 0x81;
     *ptr++ = 0x7F;
-    *ptr++ = app_total_size >> 24;
-    *ptr++ = app_total_size >> 16;
-    *ptr++ = app_total_size >> 8;
-    *ptr++ = app_total_size >> 0;
+    *ptr++ = app_extended_size >> 24;
+    *ptr++ = app_extended_size >> 16;
+    *ptr++ = app_extended_size >> 8;
+    *ptr++ = app_extended_size >> 0;
 
     /* Application Metadata */
     ptr = &output_data[TI8EK_APP_METADATA_OFFSET];
@@ -888,13 +899,23 @@ static int convert_8ek(struct input *input, struct output_file *file)
     *ptr++ = tmp >> 0;
     *ptr++ = tmp >> 8;
     *ptr++ = tmp >> 16;
+    ptr = &output_data[TI8EK_APP_METADATA_OFFSET + 0x15];
+    tmp = init_data_size > 0 ? (0x2A + reloc_size + init_data_offset) : 0;
+    *ptr++ = tmp >> 0;
+    *ptr++ = tmp >> 8;
+    *ptr++ = tmp >> 16;
+    ptr = &output_data[TI8EK_APP_METADATA_OFFSET + 0x18];
+    tmp = init_data_size;
+    *ptr++ = tmp >> 0;
+    *ptr++ = tmp >> 8;
+    *ptr++ = tmp >> 16;
     ptr = &output_data[TI8EK_APP_METADATA_OFFSET + 0x1B];
     tmp = 0x2A + reloc_size;
     *ptr++ = tmp >> 0;
     *ptr++ = tmp >> 8;
     *ptr++ = tmp >> 16;
     ptr = &output_data[TI8EK_APP_METADATA_OFFSET + 0x24];
-    tmp = 0x2A + reloc_size + input_size;
+    tmp = file->description_size ? (0x2A + reloc_size + input_size) : 3;
     *ptr++ = tmp >> 0;
     *ptr++ = tmp >> 8;
     *ptr++ = tmp >> 16;

--- a/src/elf.c
+++ b/src/elf.c
@@ -51,6 +51,8 @@
 #define SHT_RELA 4
 #define SHF_ALLOC 0x2
 #define SHN_ABS 0xfff1
+#define R_Z80_NONE 0
+#define R_Z80_8_PCREL 3
 #define R_Z80_24 5
 
 /* ELF32 structures */
@@ -585,6 +587,13 @@ static int extract_relocations(FILE *fd, uint8_t *data, size_t data_size, uint32
 
             if (r_type != R_Z80_24)
             {
+                /* Not handled for now, but doesn't prevent things from working */
+                if (r_type == R_Z80_NONE || r_type == R_Z80_8_PCREL)
+                {
+                    LOG_DEBUG("Ignoring relocation type: %u (%s)\n",
+                            r_type, r_type == R_Z80_NONE ? "R_Z80_NONE" : "R_Z80_8_PCREL");
+                    continue;
+                }
                 LOG_ERROR("Unsupported relocation type: %u (expected R_Z80_24)\n", r_type);
                 free(rela_data);
                 free(symtab_data);

--- a/src/elf.c
+++ b/src/elf.c
@@ -710,6 +710,14 @@ int elf_extract_binary(FILE *fd, uint8_t **data, size_t *size, struct app_reloc_
         return -1;
     }
 
+    if (reloc_table != NULL)
+    {
+        reloc_table->data = NULL;
+        reloc_table->size = 0;
+        reloc_table->init_offset = 0;
+        reloc_table->init_size = 0;
+    }
+
     if (fseek(fd, 0, SEEK_SET) != 0)
     {
         LOG_ERROR("Failed to seek to beginning of file.\n");
@@ -829,6 +837,37 @@ int elf_extract_binary(FILE *fd, uint8_t **data, size_t *size, struct app_reloc_
         {
             LOG_ERROR("Failed to read segment data.\n");
             goto cleanup;
+        }
+    }
+
+    if (reloc_table != NULL)
+    {
+        uint32_t init_start = UINT32_MAX;
+        uint32_t init_end = 0;
+
+        for (i = 0; i < num_segments; i++)
+        {
+            if (segments[i].memsz > 0 && segments[i].vaddr != segments[i].paddr)
+            {
+                uint32_t seg_start = segments[i].paddr - min_paddr;
+                uint32_t seg_end = seg_start + segments[i].memsz;
+
+                if (seg_start < init_start)
+                {
+                    init_start = seg_start;
+                }
+
+                if (seg_end > init_end)
+                {
+                    init_end = seg_end;
+                }
+            }
+        }
+
+        if (init_start < init_end)
+        {
+            reloc_table->init_offset = init_start;
+            reloc_table->init_size = init_end - init_start;
         }
     }
 

--- a/src/elf.h
+++ b/src/elf.h
@@ -44,6 +44,8 @@ struct app_reloc_table
 {
     uint8_t *data;
     size_t size;
+    uint32_t init_offset;
+    uint32_t init_size;
 };
 
 int elf_extract_binary(FILE *fd, uint8_t **data, size_t *size, struct app_reloc_table *reloc_table);

--- a/src/input.c
+++ b/src/input.c
@@ -332,6 +332,8 @@ int input_add_file_path(struct input *input, const char *path)
     f->data = NULL;
     f->reloc_table.data = NULL;
     f->reloc_table.size = 0;
+    f->reloc_table.init_offset = 0;
+    f->reloc_table.init_size = 0;
 
     input->nr_files++;
 


### PR DESCRIPTION
Successfully tested with various obj from the nightly toolchain that now work fine in CEmu:
- with and without an app description
- with and without relocations

The previous code didn't actually generate valid .8ek files (confirmed by LogicalJoe's HexFiend templates + CEmu throwing a "Transfer warning: file parsing failed" error), or at least not always.