### PR TITLE
Suppress -Wtype-limits when long is 32-bits

### DIFF
--- a/src/deps/miniz/miniz.c
+++ b/src/deps/miniz/miniz.c
@@ -323,7 +323,8 @@ int mz_compress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned char 
     memset(&stream, 0, sizeof(stream));
 
     /* In case mz_ulong is 64-bits (argh I hate longs). */
-    if ((mz_uint64)(source_len | *pDest_len) > 0xFFFFFFFFU)
+    /* Compare >= instead of > to suppress -Wtype-limits when long is 32-bits */
+    if ((mz_uint64)(source_len | *pDest_len) >= 0xFFFFFFFFU)
         return MZ_PARAM_ERROR;
 
     stream.next_in = pSource;
@@ -566,7 +567,8 @@ int mz_uncompress2(unsigned char *pDest, mz_ulong *pDest_len, const unsigned cha
     memset(&stream, 0, sizeof(stream));
 
     /* In case mz_ulong is 64-bits (argh I hate longs). */
-    if ((mz_uint64)(*pSource_len | *pDest_len) > 0xFFFFFFFFU)
+    /* Compare >= instead of > to suppress -Wtype-limits when long is 32-bits */
+    if ((mz_uint64)(*pSource_len | *pDest_len) >= 0xFFFFFFFFU)
         return MZ_PARAM_ERROR;
 
     stream.next_in = pSource;


### PR DESCRIPTION
Fixes these warnings when `long` is 32-bits:
```c
src\deps\miniz\miniz.c: In function 'mz_compress2':
src\deps\miniz\miniz.c:326:46: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  326 |     if ((mz_uint64)(source_len | *pDest_len) > 0xFFFFFFFFU)
      |                                              ^
src\deps\miniz\miniz.c: In function 'mz_uncompress2':
src\deps\miniz\miniz.c:569:48: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  569 |     if ((mz_uint64)(*pSource_len | *pDest_len) > 0xFFFFFFFFU)
      |                                                ^
( mkdir obj\deps\zx\zx7 2>nul || call )
```

This PR does slightly change the behavior so the maximum size is `2^32 - 2` instead of `2^32 - 1`, but a file that large is probably erroneous anyways.